### PR TITLE
Controller does not work with angular 1.3

### DIFF
--- a/src/directives/dxTree.js
+++ b/src/directives/dxTree.js
@@ -3,13 +3,12 @@
 
     comp.controller("dxTreeCtrl", [function () {
         var template;
-        return {
-            template: function (value) {
-                if (angular.isDefined(value)) {
-                    template = value;
-                } else {
-                    return template;
-                }
+        
+        this.template = function (value) {
+            if (angular.isDefined(value)) {
+                template = value;
+            } else {
+                return template;
             }
         };
     }]);


### PR DESCRIPTION
Only properties exposed on 'this' are visible in directives that require the controller in angular 1.3
